### PR TITLE
Support dir case

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,9 +21,11 @@ function map(patterns) {
     // Account for files and directories.
     patterns = patterns.map(function(pattern) {
         if (!isFile(pattern)) {
-            // Create pair of globs.
-            if (pattern.slice(-1) !== '/') {
-                var suffix = (pattern.slice(-1) == '*') ? '*' : '/**'
+            var suffix = (pattern.slice(-1) == '*') ? '*' : '/**';
+            if (pattern.slice(-1) === '/') {
+              pattern = [pattern + suffix];
+            } else {
+              // Create pair of globs.
                 pattern = [pattern, pattern + suffix];
             }
         }

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,16 @@ describe('Globs', function() {
         expect(result).to.eql(['/foo', '/foo/', 'bar/foo', 'bar/foo/baz']);
     });
 
+    it('should match dir', function() {
+        var files = ['/foo', '/foo/', 'bar', 'bar/foo', 'bar/foo/baz'];
+        var patterns = ['foo/'];
+
+        var globs = parse._map(patterns);
+        var result = multimatch(files, globs);
+
+        expect(result).to.eql(['/foo/', 'bar/foo/baz']);
+    });
+
     it('should match glob pattern', function() {
         var files = ['bar', 'foo/', 'foo/bar', 'foo/bar/baz'];
         var patterns = ['foo/*'];


### PR DESCRIPTION
`foo/` should produce the glob `**/foo/**`. This is an example in the
readme, but this isn't how this module currently works.